### PR TITLE
Bower dependency git URL

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
         }
     ],
     "dependencies": {
-        "jquery": "git@github.com:m1ke/jquery-bower.git"
+        "jquery": "M1ke/jquery-bower"
     },
     "description": "Quickly access browser print dialoguses using a dynamic iframe",
     "files": [


### PR DESCRIPTION
This points to the private git url, and this fails for me. (because my ssh config makes it use my own github key, which get an access denied for this repository).

To solve this the public url could be used (git://github.com/m1ke/jquery-bower.git)
Or even better, just the shorthand "m1ke/jquery-bower", which should make bower use the default 'https' url.
